### PR TITLE
Fixes/error no members handling

### DIFF
--- a/lib/riak/connection.ex
+++ b/lib/riak/connection.ex
@@ -3,7 +3,6 @@ defmodule Riak.Connection do
   Create a linked process to talk with the riak server on host:port.
   """
   def start_link(host \\ '127.0.0.1', port \\ 8087, args \\ []) do
-    init_seed()
     :riakc_pb_socket.start_link(host, port, args)
   end
 
@@ -11,13 +10,6 @@ defmodule Riak.Connection do
   Create a process to talk with the riak server on host:port.
   """
   def start(host \\ '127.0.0.1', port \\ 8087, args \\ []) do
-    init_seed()
     :riakc_pb_socket.start(host, port, args)
-  end
-
-  defp init_seed do
-    # Let's initialize a seed for pseudo uniform random number - no periodic
-    << a :: 32, b :: 32, c :: 32 >> = :crypto.rand_bytes(12)
-    :random.seed(a, b, c)
   end
 end

--- a/lib/riak/connection.ex
+++ b/lib/riak/connection.ex
@@ -3,6 +3,7 @@ defmodule Riak.Connection do
   Create a linked process to talk with the riak server on host:port.
   """
   def start_link(host \\ '127.0.0.1', port \\ 8087, args \\ []) do
+    init_seed()
     :riakc_pb_socket.start_link(host, port, args)
   end
 
@@ -10,6 +11,13 @@ defmodule Riak.Connection do
   Create a process to talk with the riak server on host:port.
   """
   def start(host \\ '127.0.0.1', port \\ 8087, args \\ []) do
+    init_seed()
     :riakc_pb_socket.start(host, port, args)
+  end
+
+  defp init_seed do
+    # Let's initialize a seed for pseudo uniform random number - no periodic
+    << a :: 32, b :: 32, c :: 32 >> = :crypto.rand_bytes(12)
+    :random.seed(a, b, c)
   end
 end

--- a/lib/riak/crdt/counter.ex
+++ b/lib/riak/crdt/counter.ex
@@ -12,7 +12,8 @@ defmodule Riak.CRDT.Counter do
   @doc """
   Increment a `counter` on the `amount` defaulting in 1
   """
-  def increment(counter, amount \\ 1) when Record.is_record(counter, :counter) do
+  def increment(counter, amount \\ 1)
+  def increment(counter, amount) when Record.is_record(counter, :counter) do
     :riakc_counter.increment(amount, counter)
   end
   def increment(nil, _), do: {:error, :nil_object}
@@ -20,7 +21,8 @@ defmodule Riak.CRDT.Counter do
   @doc """
   Decrement a `counter` on the `amount` defaulting in 1
   """
-  def decrement(counter, amount \\ 1) when Record.is_record(counter, :counter) do
+  def decrement(counter, amount \\ 1)
+  def decrement(counter, amount) when Record.is_record(counter, :counter) do
     :riakc_counter.increment(-amount, counter)
   end
   def decrement(nil, _), do: {:error, :nil_object}


### PR DESCRIPTION
Simple handling of :pooler.take_group_member when returning :error_no_members
Now when we receive such value, we make a new call after a random time.