### PR TITLE
Graceful handling of deleted values.

### DIFF
--- a/lib/riak.ex
+++ b/lib/riak.ex
@@ -308,16 +308,10 @@ defmodule Riak do
 
   # [["X-Riak-Deleted" | true]]
   defp sibling_deleted?(md) do
-    md
-    |> Tuple.to_list
-    |> List.last
-    |> Tuple.to_list
-    |> List.first
-    |> Tuple.to_list
-    |> Enum.any?(fn
-      [["X-Riak-Deleted" | true]] -> true
-      _ -> false
-    end)
+    presented = md
+                |> :dict.fetch_keys
+                |> Enum.find(& &1 == "X-Riak-Deleted")
+    presented && :dict.fetch("X-Riak-Deleted", md)
   end
   defp build_sibling_list([], [final_list]), do: %Riak.Object{data: final_list}
   defp build_sibling_list([], final_list), do: final_list

--- a/lib/riak.ex
+++ b/lib/riak.ex
@@ -306,8 +306,24 @@ defmodule Riak do
     end
   end
 
-  defp build_sibling_list([{_md, val}|t], final_list), do: build_sibling_list(t,[val|final_list])
+  # [["X-Riak-Deleted" | true]]
+  defp sibling_deleted?(md) do
+    md
+    |> Tuple.to_list
+    |> List.last
+    |> Tuple.to_list
+    |> List.first
+    |> Tuple.to_list
+    |> Enum.any?(fn
+      [["X-Riak-Deleted" | true]] -> true
+      _ -> false
+    end)
+  end
+  defp build_sibling_list([], [final_list]), do: %Riak.Object{data: final_list}
   defp build_sibling_list([], final_list), do: final_list
+  defp build_sibling_list([{md, val}|t], final_list) do
+    build_sibling_list(t, (if sibling_deleted?(md), do: final_list, else: [val|final_list]))
+  end
 
   @doc """
   Picks the sibling to "win" over the other siblings via a list index.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+ExUnit.configure(exclude: [skip: true])
 ExUnit.start
 
 defmodule Riak.Case do


### PR DESCRIPTION
I suddenly encountered the following problem: under some circumstances (the `bucket_type` is explicitly declared for the `bucket` and `HTTP` is used to put the values into it,) Riak marks a value as deleted, but does not delete it, resulting in `siblings` return an array of requested element and _an empty element_.

I know it sounds weird, but you might want to take a look at the patch code, that is fixing this. I added an explicit check for `"X-Riak-Deleted"` metadata to `build_sibling_list`. I tested this in my local environment, but for the sake of keeping pull request small I excluded the respective test from the default build (`@tag skip`, since it requires the bucket type to be created in advance.) Also, since now it’s possible to get a single value from `build_sibling_list`, I adopted it to construct the “fake” `Riak.Object` struct in such a case.

I understand this is not the patch that adds a readabiltiy and clearness to the existing code, but receiving deleted objects as siblings is _really annoying_.