### PR TITLE
fix: make mix.exs compatible with 1.9 releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,8 +14,7 @@ defmodule Riak.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [ applications: [ :pooler ],
-      included_applications: [ :riakc ] ]
+    [ extra_applications: [] ]
   end
 
   defp deps do


### PR DESCRIPTION
With releases we no longer need to use `included_applications` or `appications` since it's infered